### PR TITLE
Remove unneeded dependencies from build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,8 +32,3 @@ android {
         disable 'InvalidPackage'
     }
 }
-
-dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha02'
-    implementation 'androidx.core:core:1.1.0-alpha04'
-}

--- a/android/src/main/java/io/github/ponnamkarthik/toast/fluttertoast/FluttertoastPlugin.java
+++ b/android/src/main/java/io/github/ponnamkarthik/toast/fluttertoast/FluttertoastPlugin.java
@@ -11,7 +11,6 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.core.content.ContextCompat;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -88,8 +87,13 @@ public class FluttertoastPlugin implements MethodCallHandler {
 
 
             if(bgcolor != null) {
-                Drawable shapeDrawable = ContextCompat.getDrawable(ctx, R.drawable.toast_bg);
-
+                Drawable shapeDrawable; 
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    shapeDrawable = ctx.getResources().getDrawable(R.drawable.toast_bg,ctx.getTheme());
+                } else {
+                    shapeDrawable = ctx.getResources().getDrawable(R.drawable.toast_bg);
+                }
+                
                 if (shapeDrawable != null) {
                     shapeDrawable.setColorFilter(bgcolor.intValue(), PorterDuff.Mode.SRC_IN);
                     if (Build.VERSION.SDK_INT <= 27) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -58,6 +58,4 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.2-alpha01'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.2-alpha01'
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha02'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 20 12:42:32 IST 2018
+#Mon Feb 25 01:11:37 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
These dependencies caused build errors when compiled with various Google Flutter plugins.