### PR TITLE
fix pubspec web pluginClass Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.2]
+
+- Web Fix after name change
+
+
 ## [5.0.1]
 
 - Many things changes on android side (this will break your current implementation)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttertoast
 description: Toast Library for Flutter, Easily create toast messages in single line of code
-version: 5.0.1
+version: 5.0.2
 homepage: https://github.com/PonnamKarthik/FlutterToast
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,5 +22,5 @@ flutter:
       ios:
         pluginClass: FluttertoastPlugin
       web:
-        pluginClass: FluttertoastWebPlugin
+        pluginClass: FlutterToastWebPlugin
         fileName: fluttertoast_web.dart


### PR DESCRIPTION
After the update, the pluginClass name was change but not in the pubspec.

lib/generated_plugin_registrant.dart:22:60: Error: Getter not found: 'FluttertoastWebPlugin'.
  FluttertoastWebPlugin.registerWith(registry.registrarFor(FluttertoastWebPlugin)); 