### PR TITLE
The class variable name is invalid and not related to the document.

### DIFF
--- a/lib/fluttertoast.dart
+++ b/lib/fluttertoast.dart
@@ -7,7 +7,7 @@ enum Toast { LENGTH_SHORT, LENGTH_LONG }
 
 enum ToastGravity { TOP, BOTTOM, CENTER, TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT, CENTER_LEFT, CENTER_RIGHT }
 
-class Fluttertoast {
+class FlutterToast {
   static const MethodChannel _channel = const MethodChannel('PonnamKarthik/fluttertoast');
 
   static Future<bool> cancel() async {


### PR DESCRIPTION
The class variable name is invalid and not related to the document.

I think it's necessary because sometimes it can confuse new users.

Please consider.