### PR TITLE
Fixed IOS Toast message shown below the keyboard if open or other views

### DIFF
--- a/ios/Classes/FluttertoastPlugin.m
+++ b/ios/Classes/FluttertoastPlugin.m
@@ -94,12 +94,7 @@ static NSString *const CHANNEL_NAME = @"PonnamKarthik/fluttertoast";
 #pragma mark - read the key window
 
 - (UIWindow *)_readKeyWindow {
-    for (UIWindow *window in UIApplication.sharedApplication.windows) {
-        if ([window isKindOfClass:UIWindow.class] && window.isKeyWindow && window.windowLevel == UIWindowLevelNormal) {
-            return window;
-        }
-    }
-    return nil;
+    return [[UIApplication sharedApplication].windows lastObject];
 }
 
 @end


### PR DESCRIPTION
The Toast Message will now appear above all views as its directly added to the top most view of the window for IOS