### PR TITLE
Safely call 'cancel' on Android even if lateinit property 'mToast' had not been initialized beforehand

### DIFF
--- a/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
@@ -83,7 +83,9 @@ internal class MethodCallHandlerImpl(var context: Context) : MethodCallHandler {
                 result.success(true)
             }
             "cancel" -> {
-                mToast.cancel()
+                if (::mToast.isInitialized) {
+                    mToast.cancel()
+                }
                 result.success(true)
             }
             else -> result.notImplemented()


### PR DESCRIPTION
Calling `cancel` before `showToast` makes apps crash with the following Kotlin exception message: `lateinit property mToast not initialized`.
In my apps, I needed to "cancel" any pending Toasts (before they disappear on their own) prior to displaying new ones, and this is why I stumbled upon this particular corner case. Rather than explicitly handling that very first interaction with FlutterToast, I thought it would be more useful to just do nothing if  `cancel` is called without a prior call to `showToast`.
Feel free to close this PR if you think it doesn't make sense.
Thanks!
