### PR TITLE
Android Fixed Circular borders are gone (#225)

### DIFF
--- a/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
@@ -49,7 +49,7 @@ internal class MethodCallHandlerImpl(var context: Context) : MethodCallHandler {
                         context.resources.getDrawable(R.drawable.corner)
                     }
                     if(bgcolor != null) {
-                        gradientDrawable.setColorFilter(bgcolor.toInt(), PorterDuff.Mode.SRC)
+                        gradientDrawable.setColorFilter(bgcolor.toInt(), PorterDuff.Mode.SRC_IN)
                     }
                     text.background = gradientDrawable
                     if(textSize != null) {


### PR DESCRIPTION
## Description
The `gradientDrawable` corner settings were unstable, so I changed `PorterDuff.Mode` to use the corners of the inflated layout.

## Related Issues
issue #225 

## Screen Capture

|before|after|
|------|-----|
|<img src=https://user-images.githubusercontent.com/1748326/96360285-c4b52e80-1156-11eb-8a7b-de78bca0a97a.gif  width=50%>|<img src=https://user-images.githubusercontent.com/1748326/96360288-c7b01f00-1156-11eb-9f54-83c800e75114.gif  width=50%>|