### PR TITLE
Fix crash with text include newline character(\n) on web

### DIFF
--- a/lib/fluttertoast_web.dart
+++ b/lib/fluttertoast_web.dart
@@ -78,7 +78,7 @@ class FluttertoastWebPlugin {
       int time = 3000,
       bool showClose = false,
       int textColor}) {
-    String m = msg.replaceAll("'", "\\'");
+    String m = msg.replaceAll("'", "\\'").replaceAll("\n", "<br />");
     html.Element ele = html.querySelector("#toast-content");
     String content = """
           var toastElement = Toastify({


### PR DESCRIPTION
## Description
When using the newline character(`\n`), `showToast` is crashed with printing the below error.

<details>
  <summary>Error log</summary>
  
```
Uncaught SyntaxError: Invalid or unexpected token
    at HTMLHeadElement.[dartx.append] (html_dart2js.dart:23451)
    at html$._ChildrenElementList._wrap.add (html_dart2js.dart:11765)
    at fluttertoast_web.FluttertoastWebPlugin.new.addHtmlToast (fluttertoast_web.dart:100)
    at fluttertoast_web.FluttertoastWebPlugin.new.showToast (fluttertoast_web.dart:47)
    at fluttertoast_web.FluttertoastWebPlugin.new.handleMethodCall (fluttertoast_web.dart:20)
    at handleMethodCall.next (<anonymous>)
    at runBody (async_patch.dart:84)
    at Object._async [as async] (async_patch.dart:123)
    at fluttertoast_web.FluttertoastWebPlugin.new.handleMethodCall (fluttertoast_web.dart:17)
    at platform_channel.MethodChannel.new._handleAsMethodCall (platform_channel.dart:435)
    at _handleAsMethodCall.next (<anonymous>)
    at runBody (async_patch.dart:84)
    at Object._async [as async] (async_patch.dart:123)
    at platform_channel.MethodChannel.new.[_handleAsMethodCall] (platform_channel.dart:432)
    at platform_channel.dart:382
    at plugin_registry.PluginRegistry.new.handleFrameworkMessage (plugin_registry.dart:115)
    at handleFrameworkMessage.next (<anonymous>)
    at runBody (async_patch.dart:84)
    at Object._async [as async] (async_patch.dart:123)
    at plugin_registry.PluginRegistry.new.handleFrameworkMessage (plugin_registry.dart:106)
    at _engine.EnginePlatformDispatcher.__.[_sendPlatformMessage] (platform_dispatcher.dart:428)
    at _engine.EnginePlatformDispatcher.__.sendPlatformMessage (platform_dispatcher.dart:216)
    at _DefaultBinaryMessenger.[_sendPlatformMessage] (binding.dart:259)
    at _DefaultBinaryMessenger.send (binding.dart:308)
    at MethodChannel._invokeMethod (platform_channel.dart:148)
    at _invokeMethod.next (<anonymous>)
    at runBody (async_patch.dart:84)
    at Object._async [as async] (async_patch.dart:123)
    at MethodChannel.[_invokeMethod] (platform_channel.dart:146)
    at MethodChannel.invokeMethod (platform_channel.dart:331)
    at showToast (fluttertoast.dart:78)
    at showToast.next (<anonymous>)
    at runBody (async_patch.dart:84)
    at Object._async [as async] (async_patch.dart:123)
    at Function.showToast (fluttertoast.dart:30)
    at _ToastService.showToast (VM234 toastService.dart.lib.js:34)
    at developer_service._DeveloperService.new.toggleDevMode (VM235 developer_service.dart.lib.js:24)
    at multiple_tap_detector.MultipleTapDetector.new.<anonymous> (VM41 company_analysis_history_section.dart.lib.js:18609)
    at multiple_tap_detector.dart:29
    at _rootRunUnary (zone.dart:1194)
    at async._CustomZone.new.runUnary (zone.dart:1097)
    at async._CustomZone.new.runUnaryGuarded (zone.dart:1002)
    at _ForwardingStreamSubscription.new.[_sendData] (stream_impl.dart:357)
    at _ForwardingStreamSubscription.new.[_add] (stream_impl.dart:285)
    at _ForwardingStreamSubscription.new.[_add] (stream_pipe.dart:127)
    at _WhereStream.new.[_handleData] (stream_pipe.dart:199)
    at _ForwardingStreamSubscription.new.[_handleData] (stream_pipe.dart:157)
    at _rootRunUnary (zone.dart:1194)
    at async._CustomZone.new.runUnary (zone.dart:1097)
    at async._CustomZone.new.runUnaryGuarded (zone.dart:1002)
    at _BroadcastSubscription.new.[_sendData] (stream_impl.dart:357)
    at _BroadcastSubscription.new.[_add] (stream_impl.dart:285)
    at _SyncBroadcastStreamController.new.[_sendData] (broadcast_stream_controller.dart:384)
    at _SyncBroadcastStreamController.new.add (broadcast_stream_controller.dart:250)
    at _BackpressureStreamSink.new.resolveWindowEnd (backpressure.dart:188)
    at backpressure.dart:149
    at _rootRunUnary (zone.dart:1194)
    at async._CustomZone.new.runUnary (zone.dart:1097)
    at async._CustomZone.new.runUnaryGuarded (zone.dart:1002)
    at _BroadcastSubscription.new.[_sendData] (stream_impl.dart:357)
    at _BroadcastSubscription.new.[_add] (stream_impl.dart:285)
    at _SyncBroadcastStreamController.new.[_sendData] (broadcast_stream_controller.dart:384)
    at _SyncBroadcastStreamController.new.add (broadcast_stream_controller.dart:250)
    at _BackpressureStreamSink.new.resolveWindowEnd (backpressure.dart:188)
    at backpressure.dart:142
    at _rootRun (zone.dart:1178)
    at async._CustomZone.new.run (zone.dart:1090)
    at async._CustomZone.new.runGuarded (zone.dart:994)
    at sendDone (stream_impl.dart:410)
    at _rootRun (zone.dart:1178)
    at async._CustomZone.new.run (zone.dart:1090)
    at _FutureListener.whenComplete.handleWhenComplete (future_impl.dart:174)
    at handleWhenCompleteCallback (future_impl.dart:678)
    at Function._propagateToListeners (future_impl.dart:734)
    at async._AsyncCallbackEntry.new.callback (future_impl.dart:405)
    at Object._microtaskLoop (schedule_microtask.dart:41)
    at _startMicrotaskLoop (schedule_microtask.dart:50)
    at async_patch.dart:166
```
</details>

## Solution
Replace newline character(`\n`) to `<br />` tag