### PR TITLE
fix: #298 safe call Android view object

### DIFF
--- a/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
@@ -126,7 +126,7 @@ internal class MethodCallHandlerImpl(var context: Context) : MethodCallHandler {
 
     fun resetToast() {
         if (::mToast.isInitialized && mToast != null) {
-            if (mToast.view.visibility != View.VISIBLE) {
+            if (mToast.view?.visibility != View.VISIBLE) {
                 mToast
             } else {
                 Handler().postDelayed(Runnable {


### PR DESCRIPTION
fix for error that says `Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type View?` on Android