### PR TITLE
Unable to launch app in iOS simulators on Apple Silicon Machines (M1 Mac) in Flutter 2.5.0

### DIFF
--- a/ios/fluttertoast.podspec
+++ b/ios/fluttertoast.podspec
@@ -16,6 +16,8 @@ Toast Library for FLutter
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Toast'
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
   s.ios.deployment_target = '8.0'
 end
 


### PR DESCRIPTION
Fix #332

Suggested solution is obtained from https://github.com/CocoaPods/CocoaPods/issues/10104#issuecomment-704862852

This issue has been found since Flutter 2.5.0.