### PR TITLE
Bug fix for running on M1 iOS simulator.

### DIFF
--- a/ios/fluttertoast.podspec
+++ b/ios/fluttertoast.podspec
@@ -16,8 +16,7 @@ Toast Library for FLutter
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Toast'
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.ios.deployment_target = '8.0'
 end
 


### PR DESCRIPTION
This change fixed https://github.com/ponnamkarthik/FlutterToast/issues/388 for me.

To get this line I have created a new empty Flutter plugin using Android Studio. Then the fluttertoast.podspec file contained this line instead of the lines that were in the FlutterToast project. After replacing them, the scrolling works fine now.