### PR TITLE
Add environment restriction in pubspec

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -182,4 +182,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=1.10.0"
+  flutter: ">=3.7.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,5 +65,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.17.0-0 <4.0.0"
-  flutter: ">=1.10.0"
+  dart: ">=2.17.0-0 <3.0.0"
+  flutter: ">=3.7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/ponnamkarthik/FlutterToast/issues
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.10.0"
+  flutter: ">=3.7.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
 the project used BuildContext.mounted and Overlay.maybeOf which is only available in version 3.7, so add environment restriction in pubspec.

https://github.com/ponnamkarthik/FlutterToast/issues/417