### PR TITLE
fix(web): get css & js urls using flutter utility

### DIFF
--- a/lib/fluttertoast_web.dart
+++ b/lib/fluttertoast_web.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:html' as html;
+import 'dart:ui' as ui;
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -70,16 +71,24 @@ class FluttertoastWebPlugin {
     final List<Future<void>> loading = <Future<void>>[];
     final List<html.HtmlElement> tags = <html.HtmlElement>[];
 
+    // ignore: undefined_prefixed_name
+    final cssUrl = ui.webOnlyAssetManager.getAssetUrl(
+      'packages/fluttertoast/assets/toastify.css',
+    );
     final html.LinkElement css = html.LinkElement()
       ..id = 'toast-css'
       ..attributes = {"rel": "stylesheet"}
-      ..href = 'assets/packages/fluttertoast/assets/toastify.css';
+      ..href = cssUrl;
     tags.add(css);
 
+    // ignore: undefined_prefixed_name
+    final jsUrl = ui.webOnlyAssetManager.getAssetUrl(
+      'packages/fluttertoast/assets/toastify.js',
+    );
     final html.ScriptElement script = html.ScriptElement()
       ..async = true
       // ..defer = true
-      ..src = "assets/packages/fluttertoast/assets/toastify.js";
+      ..src = jsUrl;
     loading.add(script.onLoad.first);
     tags.add(script);
     html.querySelector('head')!.children.addAll(tags);


### PR DESCRIPTION
In Flutter it is possible to customize the location that assets will be loaded from  (e.g. using `assetBase` meta tag or providing this property to engine initializer directly)
Current solution assumes that js script and css file are always under `<rootUrl>/assets/` directory, which is not true if `assetBase` is used. So in the current PR I use `getAssetUrl` utility provided by Flutter that respects `assetBase`

https://github.com/flutter/engine/blob/942909b77001b4904e26aa29e3cac63345108a0a/lib/web_ui/lib/ui_web/src/ui_web/asset_manager.dart#L76-L81