### PR TITLE
Removing VALID_ARCHS from `pod_target_xcconfig` in iOS podspec

### DIFF
--- a/ios/fluttertoast.podspec
+++ b/ios/fluttertoast.podspec
@@ -16,6 +16,6 @@ Toast Library for FLutter
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Toast'
-  s.pod_target_xcconfig = {'VALID_ARCHS' => 'x86_64 armv7 arm64', 'DEFINES_MODULE' => 'YES'}
+  s.pod_target_xcconfig = {'DEFINES_MODULE' => 'YES'}
   s.resource_bundles = {'fluttertoast_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
Fixes https://github.com/ponnamkarthik/FlutterToast/issues/463

### Background

Prior to https://github.com/ponnamkarthik/FlutterToast/pull/405, this line matched the [flutter plugin template](https://github.com/flutter/flutter/blob/140edb9883122e335ecb99416934c9436d6a6d10/packages/flutter_tools/templates/plugin_ffi/ios.tmpl/projectName.podspec.tmp)
```
`s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }` 
```

In #405, `arm64` was added to `EXCLUDED_ARCHS[sdk=iphonesimulator*]` to work around dependencies missing `arm64` slices for simulator, but that change is no longer necessary: https://github.com/CocoaPods/CocoaPods/issues/10104#issuecomment-704916617.

In #425, the line was changed to add `VALID_ARCHS`, which is a deprecated build setting ([source](https://developer.apple.com/documentation/technotes/tn3117-resolving-build-errors-for-apple-silicon/)).

Most other common flutter packages don't have `VALID_ARCHS` set in their podspec.

### What changes in this PR

`VALID_ARCHS` is removed -- it's no longer necessary, and was breaking release builds (#463) for some users
