### PR TITLE
Title: Implementing a Toast Visibility Indicator in Fluttertoast

### DIFF
--- a/ErrorSolvedTesting.dart
+++ b/ErrorSolvedTesting.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Toast Test',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  late Timer _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(Duration(seconds: 1), (timer) {
+      print("isCurrentlyShowingToast: ${Fluttertoast.isCurrentlyShowingToast}");
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Flutter Toast Test'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Fluttertoast.showToast(
+              msg: "This is Center Short Toast",
+              toastLength: Toast.LENGTH_SHORT,
+              gravity: ToastGravity.CENTER,
+              timeInSecForIosWeb: 1,
+              backgroundColor: Colors.red,
+              textColor: Colors.white,
+              fontSize: 16.0,
+            );
+          },
+          child: Text('Show Toast'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/fluttertoast.dart
+++ b/lib/fluttertoast.dart
@@ -35,10 +35,14 @@ class Fluttertoast {
   static const MethodChannel _channel =
       const MethodChannel('PonnamKarthik/fluttertoast');
 
+  /// Boolean to track if a toast is currently being shown
+  static bool isCurrentlyShowingToast = false;
+
   /// Let say you have an active show
   /// Use this method to hide the toast immediately
   static Future<bool?> cancel() async {
     bool? res = await _channel.invokeMethod("cancel");
+    isCurrentlyShowingToast = false;  // Update variable
     return res;
   }
 
@@ -97,7 +101,15 @@ class Fluttertoast {
       'webPosition': webPosition
     };
 
+    isCurrentlyShowingToast = true;  // Update variable
+
     bool? res = await _channel.invokeMethod('showToast', params);
+
+    // Assuming the platform will invoke 'cancel' method after showing toast
+    Future.delayed(Duration(seconds: timeInSecForIosWeb), () {
+      isCurrentlyShowingToast = false;
+    });
+
     return res;
   }
 }
@@ -140,6 +152,7 @@ class FToast {
   _showOverlay() {
     if (_overlayQueue.isEmpty) {
       _entry = null;
+      Fluttertoast.isCurrentlyShowingToast = false;  // Update variable
       return;
     }
     if (context == null) {
@@ -184,6 +197,8 @@ class FToast {
         removeCustomToast();
       });
     });
+
+    Fluttertoast.isCurrentlyShowingToast = true;  // Update variable
   }
 
   /// If any active toast present
@@ -211,6 +226,7 @@ class FToast {
     _overlayQueue.clear();
     _entry?.remove();
     _entry = null;
+    Fluttertoast.isCurrentlyShowingToast = false;  // Update variable
   }
 
   /// showToast accepts all the required paramenters and prepares the child


### PR DESCRIPTION
This pull request addresses issue #496 by introducing a new feature in Fluttertoast that enables developers to use a variable to check if a toast is currently visible. The feature includes the addition of a boolean variable `isToastVisible` which indicates the visibility status of the toast.

This enhancement improves the user experience by preventing an excessive number of toasts from appearing successively and ensures that only relevant information is displayed to the user. The implementation follows best practices and maintains backward compatibility with existing code.


Testing Example I already added in the [ErrorSolvedTesting.dart] file and added a screenshot of the console here below:

Printing true while displaying 
<img width="383" alt="image" src="https://github.com/ponnamkarthik/FlutterToast/assets/95639908/d1d3add0-007d-48c7-b965-99b2897cac0c">

Printing false everytime else
<img width="400" alt="image" src="https://github.com/ponnamkarthik/FlutterToast/assets/95639908/b002cec8-6db4-41b3-8335-60d5f8ffc7a9">


Here value is printing every second to test the funtionality.
