### PR TITLE
Fix Directionality issue

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -78,7 +78,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "8.2.5"
+    version: "8.2.6"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/fluttertoast.dart
+++ b/lib/fluttertoast.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -309,8 +310,6 @@ TransitionBuilder FToastBuilder() {
 
 /// Simple StatelessWidget which holds the child
 /// and creates an [Overlay] to display the toast
-/// which returns the Directionality widget with [TextDirection.ltr]
-/// and [Overlay] widget
 class _FToastHolder extends StatelessWidget {
   const _FToastHolder({Key? key, required this.child}) : super(key: key);
 
@@ -318,7 +317,7 @@ class _FToastHolder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Overlay overlay = Overlay(
+    return Overlay(
       initialEntries: <OverlayEntry>[
         OverlayEntry(
           builder: (BuildContext ctx) {
@@ -326,11 +325,6 @@ class _FToastHolder extends StatelessWidget {
           },
         ),
       ],
-    );
-
-    return Directionality(
-      textDirection: TextDirection.ltr,
-      child: overlay,
     );
   }
 }


### PR DESCRIPTION
The _FToastHolder which returns the Overlay widget with a specific directionality [Directionality.ltr] prevents the app from mirroring when we switch the localization to  a new locale that uses [Directionality.rtl] and after removing it the issue fixes