### PR TITLE
Allow to use a font asset on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Fluttertoast.showToast(
 | backgroundColor         | Colors.red                                                         |null   |
 | textcolor       | Colors.white                                                       |null    |
 | fontSize        | 16.0 (float)                                                       | null      |
+| fontAsset       | Path to a font file in the Flutter app assets folder, e.g. 'assets/path/to/some-font.ttf' (String) | null      |
 | webShowClose    | false (bool)                                                       | false      |
 | webBgColor      | String (hex Color)                                                 | linear-gradient(to right, #00b09b, #96c93d) |
 | webPosition     | String (`left`, `center` or `right`)                                | right     |

--- a/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
@@ -18,7 +18,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.view.FlutterMain
 import java.io.File
 
-
 internal class MethodCallHandlerImpl(private var context: Context) : MethodCallHandler {
 
     private var mToast: Toast? = null
@@ -51,7 +50,6 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                     val text = layout.findViewById<TextView>(R.id.text,)
                     text.text = mMessage
 
-
                     val gradientDrawable: Drawable? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                         context.getDrawable(R.drawable.corner)!!
                     } else {
@@ -80,7 +78,7 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                 } else {
                     mToast = Toast.makeText(context, mMessage, mDuration)
                     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-                        val textView: TextView = mToast.view!!.findViewById(android.R.id.message)
+                        val textView: TextView = mToast?.view!!.findViewById(android.R.id.message)
                         if (fontSize != null) {
                             textView.textSize = fontSize.toFloat()
                         }

--- a/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
@@ -32,7 +32,7 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                 val bgcolor = call.argument<Number>("bgcolor")
                 val textcolor = call.argument<Number>("textcolor")
                 val fontSize = call.argument<Number>("fontSize")
-                val fontasset = call.argument<String>("fontasset")
+                val fontAsset = call.argument<String>("fontAsset")
 
                 val mGravity: Int = when (gravity) {
                     "top" -> Gravity.TOP
@@ -71,9 +71,9 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                     mToast = Toast(context,)
                     mToast?.duration = mDuration
 
-                    if (fontasset != null) {
+                    if (fontAsset != null) {
                         val assetManager: AssetManager = context.assets
-                        val key = FlutterMain.getLookupKeyForAsset(fontasset)
+                        val key = FlutterMain.getLookupKeyForAsset(fontAsset)
                         text.typeface = Typeface.createFromAsset(assetManager, key);
                     }
                     mToast?.view = layout
@@ -87,12 +87,12 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                         if (textcolor != null) {
                             textView.setTextColor(textcolor.toInt())
                         }
-                        if (fontasset != null) {
+                        if (fontAsset != null) {
                             val assetManager: AssetManager = context.assets
-                            val key = FlutterMain.getLookupKeyForAsset(fontasset)
+                            val key = FlutterMain.getLookupKeyForAsset(fontAsset)
                             textView.typeface = Typeface.createFromAsset(assetManager, key);
                         }
-                    } catch (e: Exception,) { }
+                    }
                 }
 
                 try {
@@ -108,7 +108,7 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                         }
                     }
                 } catch (e: Exception,) { }
-                
+
                 if (context is Activity) {
                     (context as Activity).runOnUiThread { mToast?.show() }
                 } else {

--- a/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
@@ -2,7 +2,9 @@ package io.github.ponnamkarthik.toast.fluttertoast
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.AssetManager
 import android.graphics.PorterDuff
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.view.Gravity
@@ -13,7 +15,9 @@ import androidx.core.content.ContextCompat
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import kotlin.Exception
+import io.flutter.view.FlutterMain
+import java.io.File
+
 
 internal class MethodCallHandlerImpl(private var context: Context) : MethodCallHandler {
 
@@ -22,12 +26,13 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result,) {
         when (call.method) {
             "showToast" -> {
-                val mMessage = call.argument<Any>("msg",).toString()
-                val length = call.argument<Any>("length",).toString()
-                val gravity = call.argument<Any>("gravity",).toString()
-                val bgcolor = call.argument<Number>("bgcolor",)
-                val textcolor = call.argument<Number>("textcolor",)
-                val textSize = call.argument<Number>("fontSize",)
+                val mMessage = call.argument<Any>("msg").toString()
+                val length = call.argument<Any>("length").toString()
+                val gravity = call.argument<Any>("gravity").toString()
+                val bgcolor = call.argument<Number>("bgcolor")
+                val textcolor = call.argument<Number>("textcolor")
+                val fontSize = call.argument<Number>("fontSize")
+                val fontasset = call.argument<String>("fontasset")
 
                 val mGravity: Int = when (gravity) {
                     "top" -> Gravity.TOP
@@ -46,6 +51,7 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                     val text = layout.findViewById<TextView>(R.id.text,)
                     text.text = mMessage
 
+
                     val gradientDrawable: Drawable? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                         context.getDrawable(R.drawable.corner)!!
                     } else {
@@ -55,8 +61,8 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                     gradientDrawable!!.setColorFilter(bgcolor.toInt(), PorterDuff.Mode.SRC_IN)
                     text.background = gradientDrawable
 
-                    if (textSize != null) {
-                        text.textSize = textSize.toFloat()
+                    if (fontSize != null) {
+                        text.textSize = fontSize.toFloat()
                     }
                     if (textcolor != null) {
                         text.setTextColor(textcolor.toInt())
@@ -64,16 +70,27 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
 
                     mToast = Toast(context,)
                     mToast?.duration = mDuration
+
+                    if (fontasset != null) {
+                        val assetManager: AssetManager = context.assets
+                        val key = FlutterMain.getLookupKeyForAsset(fontasset)
+                        text.typeface = Typeface.createFromAsset(assetManager, key);
+                    }
                     mToast?.view = layout
                 } else {
-                    try {
-                        mToast = Toast.makeText(context, mMessage, mDuration,)
-                        val textView: TextView = mToast?.view!!.findViewById(android.R.id.message,)
-                        if (textSize != null) {
-                            textView.textSize = textSize.toFloat()
+                    mToast = Toast.makeText(context, mMessage, mDuration)
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                        val textView: TextView = mToast.view!!.findViewById(android.R.id.message)
+                        if (fontSize != null) {
+                            textView.textSize = fontSize.toFloat()
                         }
                         if (textcolor != null) {
                             textView.setTextColor(textcolor.toInt())
+                        }
+                        if (fontasset != null) {
+                            val assetManager: AssetManager = context.assets
+                            val key = FlutterMain.getLookupKeyForAsset(fontasset)
+                            textView.typeface = Typeface.createFromAsset(assetManager, key);
                         }
                     } catch (e: Exception,) { }
                 }

--- a/lib/fluttertoast.dart
+++ b/lib/fluttertoast.dart
@@ -42,18 +42,22 @@ class Fluttertoast {
     return res;
   }
 
-  /// Summons the platform's showToast which will display the message
+  /// Show the [msg] via native platform's toast.
   ///
-  /// Wraps the platform's native Toast for android.
-  /// Wraps the Plugin https://github.com/scalessec/Toast for iOS
-  /// Wraps the https://github.com/apvarun/toastify-js for Web
+  /// On Android uses Toast.
+  /// On iOS uses https://github.com/scalessec/Toast plugin.
+  /// On web uses https://github.com/apvarun/toastify-js library.
   ///
-  /// Parameter [msg] is required and all remaining are optional
+  /// Parameter [msg] is required and all remaining are optional.
+  ///
+  /// The [fontAsset] is the path to your Flutter asset to use in toast.
+  /// If not specified platform's default font will be used.
   static Future<bool?> showToast({
     required String msg,
     Toast? toastLength,
     int timeInSecForIosWeb = 1,
     double? fontSize,
+    String? fontAsset,
     ToastGravity? gravity,
     Color? backgroundColor,
     Color? textColor,
@@ -92,6 +96,7 @@ class Fluttertoast {
       'textcolor': textColor.value,
       'iosTextcolor': textColor.value,
       'fontSize': fontSize,
+      'fontAsset': fontAsset,
       'webShowClose': webShowClose,
       'webBgColor': webBgColor,
       'webPosition': webPosition


### PR DESCRIPTION
This adds an optional parameter `fontAsset` to the `showToast` method that allows to apply a custom font from the Flutter app `assets` folder to the text of the toast on Android below [API level `30` (Android R)](https://developer.android.com/reference/android/os/Build.VERSION_CODES#R) where we have access to the `TextView`. Credit for the change goes to @nt4f04uNd. We have been using a fork with these changes for the past year.

[Usage example:](https://github.com/nt4f04uNd/sweyer/blob/86ca448fd4a396031b444f30fca4df3189b71961/lib/widgets/show_functions.dart#L25-L34)
```dart
Fluttertoast.showToast(
  msg: msg,
  fontAsset: 'assets/path/to/some-font.ttf',
);
```
| Normal toast | Toast with comic sans font |
|--------|--------|
| `Fluttertoast.showToast(msg: msg);` | `Fluttertoast.showToast(msg: msg, fontAsset: 'assets/fonts/comic-sans-ms.ttf');` |
| ![Toast with system font](https://github.com/user-attachments/assets/cc69a66b-d374-4250-aee8-ed864da73b01) | ![Toast with comic sans font](https://github.com/user-attachments/assets/e40bbf32-6396-4e59-a83d-1ebcc702a8f4) |

