### PR TITLE
Fix: #528 Error: A value of type 'JSString' can't be assigned to a variable of type 'String'. 

### DIFF
--- a/lib/fluttertoast_web.dart
+++ b/lib/fluttertoast_web.dart
@@ -125,7 +125,7 @@ class FluttertoastWebPlugin {
     }
     final web.HTMLScriptElement scriptText = web.HTMLScriptElement()
       ..id = "toast-content"
-      ..innerHTML = content.toJS;
+      ..innerHTML = content.toJS.toString();
     web.document.body!.append(scriptText);
     if (textColor != null) {
       web.Element toast = web.document.querySelector('.toastify')!;


### PR DESCRIPTION
Fixes #528
There was following compile-time error : 

Error: A value of type 'JSString' can't be assigned to a variable of type 'String'.

It is fixed by adding .toString();