### PR TITLE
Fix web support by adding !kIsWeb check to Platform check

### DIFF
--- a/lib/fluttertoast.dart
+++ b/lib/fluttertoast.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -90,10 +91,10 @@ class Fluttertoast {
       gravityToast = "bottom";
     }
 
-    if (backgroundColor == null && Platform.isIOS) {
+    if (backgroundColor == null && !kIsWeb && Platform.isIOS) {
       backgroundColor = Colors.black;
     }
-    if (textColor == null && Platform.isIOS) {
+    if (textColor == null && !kIsWeb && Platform.isIOS) {
       textColor = Colors.white;
     }
     final Map<String, dynamic> params = <String, dynamic>{


### PR DESCRIPTION
There is a current issue here:
https://github.com/ponnamkarthik/FlutterToast/issues/547

This fixes it.

```
    if (backgroundColor == null && !kIsWeb && Platform.isIOS) {
      backgroundColor = Colors.black;
    }
    if (textColor == null && !kIsWeb && Platform.isIOS) {
      textColor = Colors.white;
    }
```

The `!kIsWeb` check ensures that the `Platform.isIOS` check is only executed on mobile devices and not on the web platform. This prevents a crash that would occur if `Platform.isIOS` is called on the web.