### PR TITLE
fix: put back context.mounted check

### DIFF
--- a/lib/fluttertoast.dart
+++ b/lib/fluttertoast.dart
@@ -164,19 +164,18 @@ class FToast {
       throw ("Error: Context is null, Please call init(context) before showing toast.");
     }
 
-    /// To prevent exception "Looking up a deactivated widget's ancestor is unsafe."
-    /// which can be thrown if context was unmounted (e.g. screen with given context was popped)
-    /// TODO: revert this change when envoirment will be Flutter >= 3.7.0
-    // if (context?.mounted != true) {
-    //   if (kDebugMode) {
-    //     print(
-    //         'FToast: Context was unmuted, can not show ${_overlayQueue.length} toast.');
-    //   }
+    // To prevent exception "Looking up a deactivated widget's ancestor is unsafe."
+    // which can be thrown if context was unmounted (e.g. screen with given context was popped)
+    if (context?.mounted != true) {
+      if (kDebugMode) {
+        print(
+            'FToast: Context was unmuted, can not show ${_overlayQueue.length} toast.');
+      }
 
-    //   /// Need to clear queue
-    //   removeQueuedCustomToasts();
-    //   return; // Or maybe thrown error too
-    // }
+      // We should also clear the queue
+      removeQueuedCustomToasts();
+      return;
+    }
     OverlayState? _overlay;
     try {
       _overlay = Overlay.of(context!);


### PR DESCRIPTION
Hi!

We see a small number of error reports caused by unmounted context at the time `FToast.removeCustomToast` is called. 

### Scenario
We have a Flutter app integrated into the native app and this is what happens:
1. We show a toast
2. User pops the page and the whole flutter app is closed (and thus the context is unmounted)
3. FToast calls `removeCustomToast` on timer to close the toast that is shown
4. `_showOverlay` is called that tries to get the `Overlay`, but the context is unmounted
5. The error is thrown

The straightforward fix would be to just check whether the context is mounted and handle this edge case. However, I see that there is already code in place to do that, but it is commented out by this commit https://github.com/ponnamkarthik/FlutterToast/commit/5c1dd53eef3b7f8ad4fbe7318e9facfaf621c362

Do you have any context why it was commented out and whether it's still relevant? 