### PR TITLE
fix: remove debug log spam and setGravity warnings

### DIFF
--- a/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/io/github/ponnamkarthik/toast/fluttertoast/MethodCallHandlerImpl.kt
@@ -76,7 +76,6 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                     }
                     mToast?.view = layout
                 } else {
-                    Log.d("KARTHIK", "showToast: $bgcolor $textcolor $fontSize $fontAsset")
                     mToast = Toast.makeText(context, mMessage, mDuration)
                     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
                         val textView: TextView = mToast?.view!!.findViewById(android.R.id.message)
@@ -94,19 +93,23 @@ internal class MethodCallHandlerImpl(private var context: Context) : MethodCallH
                     }
                 }
 
-                try {
-                    when (mGravity) {
-                        Gravity.CENTER -> {
-                            mToast?.setGravity(mGravity, 0, 0,)
+                // Only set gravity on custom toasts (with background color)
+                // setGravity() on text toasts causes warnings in Android API 30+
+                if (bgcolor != null) {
+                    try {
+                        when (mGravity) {
+                            Gravity.CENTER -> {
+                                mToast?.setGravity(mGravity, 0, 0,)
+                            }
+                            Gravity.TOP -> {
+                                mToast?.setGravity(mGravity, 0, 100,)
+                            }
+                            else -> {
+                                mToast?.setGravity(mGravity, 0, 100,)
+                            }
                         }
-                        Gravity.TOP -> {
-                            mToast?.setGravity(mGravity, 0, 100,)
-                        }
-                        else -> {
-                            mToast?.setGravity(mGravity, 0, 100,)
-                        }
-                    }
-                } catch (e: Exception,) { }
+                    } catch (e: Exception,) { }
+                }
 
                 if (context is Activity) {
                     (context as Activity).runOnUiThread { mToast?.show() }


### PR DESCRIPTION
## Summary
- Remove debug log statement that was causing D/KARTHIK spam in Android logs
- Only call setGravity() on custom toasts with background color to avoid Android API 30+ warnings on text toasts

## Test plan
- [ ] Test basic toast functionality on Android
- [ ] Verify no more D/KARTHIK debug logs appear
- [ ] Verify no more setGravity warnings appear in Android API 30+
- [ ] Test custom toasts with background colors still respect gravity settings