### PR TITLE
fix(android): update compileSdkVersion and targetSdkVersion to 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
@@ -43,7 +43,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 34
         if (project.android.hasProperty('namespace')) {
             namespace 'io.github.ponnamkarthik.toast.fluttertoast'
         }


### PR DESCRIPTION
- Resolves build failures with Android API 34+ dependencies
- Fixes checkDebugAarMetadata task failures for fluttertoast
- Ensures compatibility with androidx dependencies requiring API 34+
- Addresses issues with androidx.fragment, androidx.window, and other dependencies

Fixes: Build failures when using fluttertoast with Android API 34+