### PR TITLE
Fix: Update Gradle & AGP versions to maintain Flutter compatibility

### DIFF
--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.0" apply false
+    id "com.android.application" version "8.7.2" apply false
     id "org.jetbrains.kotlin.android" version "2.1.20" apply false
 }
 


### PR DESCRIPTION
This PR updates the example app’s Gradle Wrapper to version 8.8 and the Android Gradle Plugin to 8.7.2, resolving build issues and ensuring future compatibility with upcoming Flutter versions. The changes have been tested on Android Studio Narwhal and Flutter 3.35.7.