### PR TITLE
fix: replace deprecated UIActivityIndicatorViewStyleWhiteLarge on iOS 13+

### DIFF
--- a/ios/fluttertoast/Sources/fluttertoast/UIView+Toast.m
+++ b/ios/fluttertoast/Sources/fluttertoast/UIView+Toast.m
@@ -395,7 +395,16 @@ static const NSString * CSToastQueueKey             = @"CSToastQueueKey";
         activityView.layer.shadowOffset = style.shadowOffset;
     }
     
-    UIActivityIndicatorView *activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+    UIActivityIndicatorView *activityIndicatorView;
+    if (@available(iOS 13.0, *)) {
+        activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+        activityIndicatorView.color = [UIColor whiteColor];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+#pragma clang diagnostic pop
+    }
     activityIndicatorView.center = CGPointMake(activityView.bounds.size.width / 2, activityView.bounds.size.height / 2);
     [activityView addSubview:activityIndicatorView];
     [activityIndicatorView startAnimating];


### PR DESCRIPTION
`makeToastActivity:` in `UIView+Toast.m` creates the loading spinner with `UIActivityIndicatorViewStyleWhiteLarge`, which Apple deprecated in iOS 13.0. Building the plugin against a current iOS SDK prints that deprecation warning on every compile. It was reported in #535 and also came up in #516.

On iOS 13 and up it now uses `UIActivityIndicatorViewStyleLarge` and sets the color to white, so the spinner looks exactly the same as before. The `Large` style is not white by default (unlike the old `WhiteLarge` constant), so the explicit color keeps the appearance identical. The pre iOS 13 path keeps the original constant but wraps it in a `clang diagnostic` push/pop so that branch stays warning free too. The `@available` guard follows the same pattern already used a bit lower in the file for the safe area insets.

There is no behavior change, it is purely a compile time warning cleanup. `Package.swift` already declares an iOS 13.0 minimum so the modern style is always available on SPM builds, and the `@available` guard keeps CocoaPods builds on older deployment targets safe.

### Testing
Compile time only change with no runtime difference. The repo's CI already runs an iOS release build for the example app, which compiles the changed file.

Closes #535
